### PR TITLE
Fallback to using DateTimeOffset.TryParse if normal parsing doesn't work

### DIFF
--- a/src/Exceptionless.DateTimeExtensions/DateMath.cs
+++ b/src/Exceptionless.DateTimeExtensions/DateMath.cs
@@ -31,6 +31,9 @@ public static class DateMath
     // Pre-compiled regex for operation parsing to avoid repeated compilation
     private static readonly Regex _operationRegex = new(@"([+\-/])(\d*)([yMwdhHms])", RegexOptions.Compiled);
 
+    // Pre-compiled regex for offset parsing to avoid repeated compilation
+    private static readonly Regex _offsetRegex = new(@"(Z|[+-]\d{2}:\d{2})$", RegexOptions.Compiled);
+
     /// <summary>
     /// Parses a date math expression and returns the resulting DateTimeOffset.
     /// </summary>
@@ -232,7 +235,7 @@ public static class DateMath
     /// <returns><see langword="true"/> when the expression is successfully parsed as an explicit date; otherwise, <see langword="false"/>.</returns>
     private static bool TryParseFallbackDate(string expression, TimeZoneInfo defaultTimeZone, bool isUpperLimit, out DateTimeOffset result)
     {
-        if (Regex.IsMatch(expression, @"(Z|[+-]\d{2}:\d{2})$") && DateTimeOffset.TryParse(expression, out DateTimeOffset explicitDate))
+        if (_offsetRegex.IsMatch(expression) && DateTimeOffset.TryParse(expression, out DateTimeOffset explicitDate))
         {
             result = explicitDate;
 
@@ -270,7 +273,7 @@ public static class DateMath
     /// <returns><see langword="true"/> when the expression is successfully parsed as an explicit date; otherwise, <see langword="false"/>.</returns>
     private static bool TryParseFallbackDate(string expression, TimeSpan offset, bool isUpperLimit, out DateTimeOffset result)
     {
-        if (Regex.IsMatch(expression, @"(Z|[+-]\d{2}:\d{2})$") && DateTimeOffset.TryParse(expression, out DateTimeOffset explicitDate))
+        if (_offsetRegex.IsMatch(expression) && DateTimeOffset.TryParse(expression, out DateTimeOffset explicitDate))
         {
             result = explicitDate;
 


### PR DESCRIPTION
This pull request enhances the date math parsing logic to support explicit date expressions as a fallback when standard date math parsing fails. Now, expressions like `"2023-01-01"` or `"2023-06-15T14:30:00"` are accepted and parsed correctly, with appropriate handling of time zones and end-of-day adjustments for upper limits. The update also significantly expands and improves the test coverage for these scenarios.

**Date parsing enhancements:**

* Added fallback logic to `DateMath.TryParse` and `IsValidExpression` to attempt parsing as an explicit date when date math parsing fails, supporting both `DateTimeOffset` and `TimeZoneInfo` contexts. This ensures that plain date strings (with or without time zone info) are now accepted and parsed correctly. [[1]](diffhunk://#diff-3721e3c07b2aa054e9a161c1b7bf20c38dbc5ad4bd5c8bf36e89a037ae8e33a5L67-R69) [[2]](diffhunk://#diff-3721e3c07b2aa054e9a161c1b7bf20c38dbc5ad4bd5c8bf36e89a037ae8e33a5L113-R117) [[3]](diffhunk://#diff-3721e3c07b2aa054e9a161c1b7bf20c38dbc5ad4bd5c8bf36e89a037ae8e33a5L214-R298)

**Test coverage improvements:**

* Updated and expanded tests in `DateMathTests.cs` to:
  * Remove invalidation of plain date strings as test cases, reflecting new acceptance of such inputs. [[1]](diffhunk://#diff-080c496831879882f62f21446f6744b6880a14f029d55c01f5a690170b855c96L314) [[2]](diffhunk://#diff-080c496831879882f62f21446f6744b6880a14f029d55c01f5a690170b855c96L371)
  * Add tests for fallback parsing, including correct offset application, end-of-day adjustment for upper limits, and preservation of explicit time zone offsets.
  * Update time zone-related tests to use plain date expressions instead of requiring the `||` anchor, verifying correct offset handling for both explicit and implicit time zones. [[1]](diffhunk://#diff-080c496831879882f62f21446f6744b6880a14f029d55c01f5a690170b855c96L559-R618) [[2]](diffhunk://#diff-080c496831879882f62f21446f6744b6880a14f029d55c01f5a690170b855c96L584-R643)
  * Add plain date strings to the list of valid expressions in theory-driven tests.

These changes make date parsing more robust, user-friendly, and consistent across different usage scenarios.